### PR TITLE
Add Japanese Name Generator to Names section

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Everything here is either system agnostic or D&D 5E unless otherwise specified.
 *Name generators*
 
 * [Fantasy Name Generators](http://fantasynamegenerators.com)
+* [Japanese Name Generator](https://japanesenamegen.com) - Authentic Japanese names with real kanji, readings and meanings; handy for eastern-inspired settings like Kara-Tur
 
 ## Maps
 


### PR DESCRIPTION
Adds [Japanese Name Generator](https://japanesenamegen.com) to the Names section.

What it offers for D&D players and DMs:
- Full Japanese names (surname + given name) drawn from a curated database of 7,000+ real names, not random syllables
- Every name shows kanji, furigana reading, romaji and meaning, so you can pick a name whose meaning fits the character
- 150+ themed lists useful at the table: samurai names, names meaning moon/fire/shadow, gender-neutral names, mythology-inspired names
- Free, no signup, works in English and Chinese

Disclosure: I built this site. Happy to adjust the entry wording or placement if you prefer.