### PR TITLE
Add One-Shot Forge generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Everything here is either system agnostic or D&D 5E unless otherwise specified.
 * [Inkarnate](https://inkarnate.com)
 * [Village generator](https://watabou.itch.io/village-generator)
 * [One Page Dungeon generator](https://watabou.itch.io/one-page-dungeon)
+* [One-Shot Forge](https://loottableworks.github.io/loot-drop-calculator/one-shot-forge/?utm_source=awesome_dnd&utm_medium=referral_directory&utm_campaign=ltw_free_tool_directory_v1&utm_content=one_shot_forge_generator) - Free, system-neutral, AI-assisted and human-reviewed generator for a five-scene one-shot, exact two- to four-hour run sheet, three to six linked pregenerated characters, a pressure clock, clues, and Markdown or JSON export.
 * [Medieval Fantasy City generator](https://watabou.itch.io/medieval-fantasy-city-generator)
 * [Perilous Shores](https://watabou.itch.io/perilous-shores)
 * [Mystic Waffle](https://www.mysticwaffle.com) - Free procedural dungeon and loot generator with a grid-based map drawing suite


### PR DESCRIPTION
Adds One-Shot Forge to the Generator section. It is a free, system-neutral one-shot generator with five-scene timing, linked pregenerated characters, a pressure clock, clues, and Markdown/JSON export.

Self-promotion disclosure: I maintain One-Shot Forge. The tool is free and system-neutral; it contains clearly labeled links to six optional $3 Loot Table Works data modules and one optional $2.99 Gullwatch Harbor campaign. Its public source uses custom source-available terms, not an open-source license. The README entry discloses AI-assisted, human-reviewed content.

I verified the destination, current README category fit, and absence of an existing One-Shot Forge entry before opening this PR.